### PR TITLE
Update to work with repackaged NMS

### DIFF
--- a/src/main/kotlin/xyz/jpenilla/toothpick/InitTasks.kt
+++ b/src/main/kotlin/xyz/jpenilla/toothpick/InitTasks.kt
@@ -29,10 +29,12 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import xyz.jpenilla.toothpick.task.ApplyPatches
+import xyz.jpenilla.toothpick.task.Clean
 import xyz.jpenilla.toothpick.task.ImportMCDev
 import xyz.jpenilla.toothpick.task.InitGitSubmodules
 import xyz.jpenilla.toothpick.task.Paperclip
 import xyz.jpenilla.toothpick.task.RebuildPatches
+import xyz.jpenilla.toothpick.task.RepackageNMS
 import xyz.jpenilla.toothpick.task.SetupUpstream
 import xyz.jpenilla.toothpick.task.UpdateUpstream
 import xyz.jpenilla.toothpick.task.UpstreamCommit
@@ -101,4 +103,18 @@ internal fun Project.initToothpickTasks() {
   tasks.register<UpstreamCommit>("upstreamCommit")
 
   registerRunTasks()
+
+  tasks.register<Clean>("cleanSubprojects") {
+    description = "Deletes the Server and API project folders. Warning! This is irreversible, and could cause you to lose work if used by mistake!"
+    clean(toothpick.apiProject.projectDir, toothpick.serverProject.projectDir)
+  }
+
+  tasks.register<Clean>("cleanToothpick") {
+    description = "Deletes the Server and API project folders, as well as the upstream folder. Warning! This is irreversible, and could cause you to lose work if used by mistake!"
+    clean(toothpick.apiProject.projectDir, toothpick.serverProject.projectDir, toothpick.upstreamDir)
+  }
+
+  tasks.register<RepackageNMS>("repackageNMS") {
+    description = "Fix patches for application after Spigot's repackaging of NMS."
+  }
 }

--- a/src/main/kotlin/xyz/jpenilla/toothpick/ToothpickExtension.kt
+++ b/src/main/kotlin/xyz/jpenilla/toothpick/ToothpickExtension.kt
@@ -86,8 +86,11 @@ public open class ToothpickExtension(objects: ObjectFactory) {
   internal val lastUpstream: File
     get() = project.projectDir.resolve("last-${upstreamLowercase}")
 
-  internal val paperWorkDir: File
+  internal val paperDecompDir: File
     get() = paperDir.resolve("work/Minecraft/${minecraftVersion}")
+
+  internal val paperWorkDir: File
+    get() = paperDir.resolve("work")
 
   internal val mavenCommand: String by lazy {
     if (exitsSuccessfully("mvn", "-v")) {

--- a/src/main/kotlin/xyz/jpenilla/toothpick/Util.kt
+++ b/src/main/kotlin/xyz/jpenilla/toothpick/Util.kt
@@ -48,13 +48,15 @@ public fun cmd(
 private fun cmdImpl(
   vararg args: String,
   dir: File,
-  printOut: Boolean = false
+  printOut: Boolean = false,
+  environment: Map<String, String> = emptyMap()
 ): CmdResult {
-  val process = ProcessBuilder()
-    .command(*args)
-    .redirectErrorStream(true)
-    .directory(dir)
-    .start()
+  val process = ProcessBuilder().apply {
+    command(*args)
+    redirectErrorStream(true)
+    directory(dir)
+    environment().putAll(environment)
+  }.start()
   val output = process.inputStream.bufferedReader().use { reader ->
     val logger = Logging.getLogger(Toothpick::class.java)
     reader.lines().asSequence()

--- a/src/main/kotlin/xyz/jpenilla/toothpick/relocation/ToothpickRelocator.kt
+++ b/src/main/kotlin/xyz/jpenilla/toothpick/relocation/ToothpickRelocator.kt
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Toothpick, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 Jason Penilla & Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package xyz.jpenilla.toothpick.relocation
+
+import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
+import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator
+import java.lang.reflect.Method
+import java.util.regex.Pattern
+
+internal class ToothpickRelocator(
+  pattern: String,
+  shadedPattern: String,
+  rawString: Boolean = false,
+  includes: List<String> = emptyList(),
+  excludes: List<String> = emptyList(),
+  private val simpleRelocator: SimpleRelocator = SimpleRelocator(pattern, shadedPattern, includes, excludes, rawString)
+) : Relocator by simpleRelocator {
+  override fun canRelocatePath(path: String): Boolean {
+    // Respect includes/excludes for rawString too
+    if (simpleRelocator.rawString) {
+      return isIncludedMethod(simpleRelocator, path) as Boolean
+        && !(isExcludedMethod(simpleRelocator, path) as Boolean)
+        && Pattern.compile(simpleRelocator.pathPattern).matcher(path).find()
+    }
+    return simpleRelocator.canRelocatePath(path)
+  }
+
+  companion object {
+    private val isExcludedMethod: Method = SimpleRelocator::class.java.getDeclaredMethod("isExcluded", String::class.java)
+    private val isIncludedMethod: Method = SimpleRelocator::class.java.getDeclaredMethod("isIncluded", String::class.java)
+
+    init {
+      isExcludedMethod.isAccessible = true
+      isIncludedMethod.isAccessible = true
+    }
+  }
+}

--- a/src/main/kotlin/xyz/jpenilla/toothpick/task/Clean.kt
+++ b/src/main/kotlin/xyz/jpenilla/toothpick/task/Clean.kt
@@ -21,19 +21,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package xyz.jpenilla.toothpick.transformer
+package xyz.jpenilla.toothpick.task
 
-import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
-import org.gradle.api.file.FileTreeElement
-import shadow.org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE
+import org.gradle.api.tasks.TaskAction
+import java.io.File
 
-internal class ModifiedLog4j2PluginsCacheFileTransformer : Transformer by Log4j2PluginsCacheFileTransformer() {
-  /**
-   * For some reason we have a file with name matching simply 'Log4j2Plugins.dat' and not PLUGIN_CACHE_FILE.
-   * That file also needs to be merged.
-   */
-  override fun canTransformResource(element: FileTreeElement): Boolean {
-    return PLUGIN_CACHE_FILE == element.name || element.name == "Log4j2Plugins.dat"
+public open class Clean : ToothpickTask() {
+  private val directoriesToClean = HashSet<File>()
+
+  public fun clean(vararg directories: File) {
+    directoriesToClean.addAll(directories)
+  }
+
+  @TaskAction
+  private fun clean() {
+    directoriesToClean.forEach { it.deleteOrNotify() }
+  }
+
+  private fun File.deleteOrNotify() {
+    logger.lifecycle("Deleting $path...")
+    val success = deleteRecursively()
+    if (success) {
+      logger.lifecycle("Successfully deleted $path.")
+    } else {
+      logger.lifecycle("Failed to delete $path.")
+    }
   }
 }

--- a/src/main/kotlin/xyz/jpenilla/toothpick/task/ImportMCDev.kt
+++ b/src/main/kotlin/xyz/jpenilla/toothpick/task/ImportMCDev.kt
@@ -30,6 +30,9 @@ import kotlinx.serialization.json.Json
 import org.gradle.api.tasks.TaskAction
 import xyz.jpenilla.toothpick.ensureSuccess
 import xyz.jpenilla.toothpick.gitCmd
+import java.io.File
+import java.nio.file.Files
+import kotlin.streams.toList
 
 private val json = Json { prettyPrint = true }
 
@@ -47,24 +50,40 @@ public open class ImportMCDev : ToothpickInternalTask() {
   private val importLog = arrayListOf("Extra mc-dev imports")
 
   private fun importNMS(className: String) {
-    logger.lifecycle("Importing n.m.s.$className")
-    val source = toothpick.paperWorkDir.resolve("spigot/net/minecraft/server/$className.java")
+    logger.lifecycle("Importing $className")
+    val classPath = "${className.replace(".", "/")}.java"
+    val source = toothpick.paperDecompDir.resolve("spigot/$classPath")
     if (!source.exists()) error("Missing NMS: $className")
-    val target = upstreamServer.resolve("src/main/java/net/minecraft/server/$className.java")
+    val target = upstreamServer.resolve("src/main/java/$classPath")
+    if (isDuplicateImport(target, className)) return
+    target.parentFile.mkdirs()
     source.copyTo(target)
-    importLog.add("Imported n.m.s.$className")
+    importLog.add("Imported $className")
   }
 
   private fun importLibrary(import: LibraryImport) {
     val (group, lib, prefix, file) = import
-    logger.lifecycle("Importing $group.$lib $prefix/$file")
-    val source = toothpick.paperWorkDir.resolve("libraries/$group/$lib/$prefix/$file.java")
+    val className = "${prefix.replace("/", ".")}.$file"
+    logger.lifecycle("Importing $className from $group.$lib")
+    val source = toothpick.paperDecompDir.resolve("libraries/$group/$lib/$prefix/$file.java")
     if (!source.exists()) error("Missing Base: $lib $prefix/$file")
     val targetDir = upstreamServer.resolve("src/main/java/$prefix")
     val target = targetDir.resolve("$file.java")
+    if (isDuplicateImport(target, className)) return
     targetDir.mkdirs()
     source.copyTo(target)
-    importLog.add("Imported $group.$lib $prefix/$file")
+    importLog.add("Imported $className from $group.$lib")
+  }
+
+  private fun isDuplicateImport(target: File, className: String): Boolean {
+    if (!target.exists()) return false
+    val message =
+      "Skipped import for $className, a class with that name already exists in the source tree. Is there an extra entry in mcdevimports.json?"
+    project.gradle.taskGraph.allTasks.last().doLast {
+      logger.warn(message)
+    }
+    logger.warn(message)
+    return true
   }
 
   @TaskAction
@@ -80,19 +99,7 @@ public open class ImportMCDev : ToothpickInternalTask() {
       )
     }
 
-    (toothpick.serverProject.patchesDir.listFiles() ?: error("No patches in server?")).asSequence()
-      .flatMap { it.readLines().asSequence() }
-      .filter { it.startsWith("+++ b/src/main/java/net/minecraft/server/") }
-      .distinct()
-      .map { it.substringAfter("/server/").substringBefore(".java") }
-      .filter { !upstreamServer.resolve("src/main/java/net/minecraft/server/$it.java").exists() }
-      .map { toothpick.paperWorkDir.resolve("spigot/net/minecraft/server/$it.java") }
-      .filter {
-        val exists = it.exists()
-        if (!it.exists()) logger.lifecycle("NMS ${it.nameWithoutExtension} is either missing, or is a new file added through a patch")
-        exists
-      }
-      .map { it.nameWithoutExtension }
+    findNeededImports(Files.list(toothpick.serverProject.patchesDir.toPath()).map { it.toFile() }.toList())
       .forEach(::importNMS)
 
     // Imports from mcdevimports.json
@@ -111,4 +118,22 @@ public open class ImportMCDev : ToothpickInternalTask() {
     }
     logger.lifecycle(">>> Done importing mc-dev")
   }
+
+  private fun findNeededImports(patches: List<File>): Set<String> = patches.asSequence()
+    .flatMap { it.readLines().asSequence() }
+    .filter { line ->
+      line.startsWith("+++ b/src/main/java/net/minecraft/")
+        || line.startsWith("+++ b/src/main/java/com/mojang/math/")
+    }
+    .distinct()
+    .map { it.substringAfter("+++ b/src/main/java/") }
+    .filter { !upstreamServer.resolve("src/main/java/$it").exists() }
+    .filter {
+      val sourceFile = toothpick.paperDecompDir.resolve("spigot/$it")
+      val exists = sourceFile.exists()
+      if (!sourceFile.exists()) logger.lifecycle("$it is either missing, or is a new file added through a patch")
+      exists
+    }
+    .map { it.replace("/", ".").substringBefore(".java") }
+    .toSet()
 }

--- a/src/main/kotlin/xyz/jpenilla/toothpick/task/RepackageNMS.kt
+++ b/src/main/kotlin/xyz/jpenilla/toothpick/task/RepackageNMS.kt
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Toothpick, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 Jason Penilla & Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package xyz.jpenilla.toothpick.task
+
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+public open class RepackageNMS : ToothpickTask() {
+  @TaskAction
+  private fun repackage() {
+    logger.lifecycle(">>> Preparing patches for NMS repackage")
+    val classMappingsFile = toothpick.paperWorkDir.resolve("BuildData/mappings/bukkit-1.16.5-cl.csrg")
+    val mappings = classMappingsFile.readLines()
+      .asSequence()
+      .filter { !it.startsWith("#") && !it.contains("$") }
+      .map { it.split(" ")[1].replace("/", ".") }
+      .map { Mapping(it) }
+      .filter { it.newFQName != it.oldFQName }
+      .toSet()
+    val remapper = Remapper(mappings)
+
+    toothpick.subprojects.values
+      .map { it.patchesDir }
+      .forEach { patchesDir ->
+        val repackagedPatchesDir =
+          patchesDir.parentFile.resolve("${patchesDir.name}_repackaged-${System.currentTimeMillis()}")
+        repackagedPatchesDir.mkdir()
+        val patchFiles = patchesDir.listFiles()?.toList() ?: error("Could not list patch files")
+        patchFiles.parallelStream().forEach { patch ->
+          logger.lifecycle("Processing ${patchesDir.name}/${patch.name}...")
+          val newPatch = repackagedPatchesDir.resolve(patch.name)
+          newPatch.writeText(remapper.remapFile(patch))
+        }
+      }
+
+    logger.lifecycle(">>> Done preparing patches")
+  }
+
+  private class Mapping(fullyQualifiedClassName: String) {
+    val className = fullyQualifiedClassName.substringAfterLast(".")
+    val oldFQName = "net.minecraft.server.$className"
+    val oldJavaFileName = "net/minecraft/server/$className.java"
+    val newFQName = fullyQualifiedClassName
+    val newJavaFileName = "${fullyQualifiedClassName.replace(".", "/")}.java"
+  }
+
+  private class Remapper(private val mappings: Set<Mapping>) {
+    fun remapFile(file: File): String =
+      file.readLines().joinToString("\n") { remapLine(it) } + "\n"
+
+    private fun remapLine(line: String): String {
+      if (
+        line.startsWith("diff --git ")
+        || line.startsWith("+++ ")
+        || line.startsWith("--- ")
+      ) {
+        var text = line
+        mappings.forEach { text = text.replace(it.oldJavaFileName, it.newJavaFileName) }
+        return text
+      }
+      if (line.startsWith("+")) {
+        var text = line
+        mappings.forEach { text = text.replace(it.oldFQName, it.newFQName) }
+        return text
+      }
+      return line
+    }
+  }
+}


### PR DESCRIPTION
See https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/90d6905b1587ac1c5c075e2da471f77d00e0f50d

Toothpick will now work properly when forking builds of Paper before or after the NMS repackage (meaning this update is not breaking).

To assist with patch migration, some new tasks have been added.
 - cleanToothpick: Deletes subproject and upstream directories
 - cleanSubprojects: Deletes subproject directories
 - repackageNMS: This task will create copies of server/api patches with file names and fully qualified class names in added lines remapped. Do not expect these modified patches to apply cleanly, however they will apply much better than attempting to apply without fixing up the patches.